### PR TITLE
Fix Python installs by adding 'import warnings' to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools.extension import Extension
 from Cython.Distutils import build_ext
 import numpy as np
 import sys, os, subprocess
+import warnings
 from os import environ
 
 found_omp = True


### PR DESCRIPTION
Currently `setup.py` crashes because it fails to import the `warnings` module; this PR fixes this problem.