### PR TITLE
add missing curly brace in approxcdf.h

### DIFF
--- a/include/approxcdf.h
+++ b/include/approxcdf.h
@@ -5,7 +5,7 @@
 #endif
 
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 
 /* Parameters


### PR DESCRIPTION
Including `approxcdf.h` into a C++ file fails to compile due a missing opening curly brace in the extern statement. This PR fixes the issue.